### PR TITLE
Prevent encrypted webm streams being passed to FFmpeg

### DIFF
--- a/dashdrm/dashdrm.py
+++ b/dashdrm/dashdrm.py
@@ -665,6 +665,14 @@ class DASHStreamDRM(DASHStream):
 
     __shortname__ = "dashdrm"
 
+    # FFmpeg's decryption_key input option is not supported by these
+    # demuxers/containers.
+    FFMPEG_UNSUPPORTED_DECRYPTION_MIME_SUBTYPES = {
+        "webm",
+        "x-matroska",
+        "x-matroska-3d",
+    }
+
     @staticmethod
     def parse_mpd(session, manifest: str, mpd_params: Mapping[str, Any]) -> MPD:
         node = parse_xml(manifest, ignore_ns=True)
@@ -730,17 +738,31 @@ class DASHStreamDRM(DASHStream):
 
         # Search for suitable video and audio representations
         for aset in period_selection.adaptationSets:
-            if aset.contentProtections:
+            aset_encrypted = bool(aset.contentProtections)
+            if aset_encrypted:
                 if not session.options.get("decryption-key"):
                     raise PluginError(f"{source} is protected by DRM but no key given")
                 else:
                     log.debug(f"{source} is protected by DRM")
             for rep in aset.representations:
+                rep_encrypted = aset_encrypted or bool(rep.contentProtections)
                 if rep.contentProtections:
                     if not session.options.get("decryption-key"):
                         raise PluginError(f"{source} is protected by DRM but no key given")
                     else:
                         log.debug(f"{source} is protected by DRM")
+
+                if rep_encrypted:
+                    mime_subtype = rep.mimeType.partition("/")[2].lower()
+                    if mime_subtype in cls.FFMPEG_UNSUPPORTED_DECRYPTION_MIME_SUBTYPES:
+                        log.debug(
+                            "Ignoring encrypted representation %s (%s): "
+                            "FFmpeg does not support decryption of this container format",
+                            rep.ident,
+                            rep.mimeType,
+                        )
+                        continue
+
                 if rep.mimeType.startswith("video"):
                     video.append(rep)
                 elif rep.mimeType.startswith("audio"):  # pragma: no branch
@@ -750,12 +772,15 @@ class DASHStreamDRM(DASHStream):
                     subtitles.append(rep)
 
                 if session.options.get("store-representation-kid"):
-                    rep.kid = cls._get_representation_kid(session, rep)
-                    log.debug(
-                        "Representation %s KID=%s",
-                        rep.ident,
-                        rep.kid,
-                    )
+                    if rep_encrypted:
+                        rep.kid = cls._get_representation_kid(session, rep)
+                        log.debug(
+                            "Representation %s KID=%s",
+                            rep.ident,
+                            rep.kid,
+                        )
+                    else:
+                        rep.kid = None
 
         if not video:
             video.append(None)
@@ -969,7 +994,7 @@ class DASHStreamDRM(DASHStream):
             if cp.default_KID:
                 return cp.default_KID.replace("-", "").lower()
 
-        # Fallback to init segment
+        # Fallback to init segment (only works for MP4)
         init = cls._get_init_segment(session, rep)
 
         if init is None:


### PR DESCRIPTION
FFmpeg only supports the decryption_key setting for mp4 style media (https://ffmpeg.org/ffmpeg-formats.html#toc-mov_002fmp4_002f3gp). As it stands, dashdrm plugin tries to pass encrypted webm streams to ffmpeg with the decryption_key flag, which then fails

You can try it with the shaka-player demo: https://shaka-project.github.io/shaka-player/docs/api/tutorial-license-server-auth.html (choose low resolution)

This change filters out mime types relating to webm/matroska if the stream is encrypted, since ffmpeg is not capable of decrypting these streams at the moment.

Before:
```
[cli][info] Available streams: 110p+a134k_alt (worst), 110p+a136k_alt, ... 1636p+a136k (best)
[cli][info] Opening stream: 110p+a134k_alt (dashdrm)

[plugins.dashdrm][debug] Opening DASH reader for: ('0', '13', '14') - video/webm
[plugins.dashdrm][debug] Opening DASH reader for: ('0', '11', '11') - audio/mp4
[plugins.dashdrm][debug] Opening DASH reader for: ('0', '12', '13') - audio/webm

Option decryption_key not found.
Error opening input file \\.\pipe\streamlinkpipe-31688-1-1384.
Error opening input files: Option not found

[cli][error] Could not open stream <DASHStreamDRM [...]> (No data returned from stream)
```

After:
```
[plugins.dashdrm][debug] Ignoring encrypted representation ('0', '12', '13') (audio/webm): FFmpeg does not support decryption of this container format
[plugins.dashdrm][debug] Ignoring encrypted representation ('0', '13', '14') (video/webm): FFmpeg does not support decryption of this container format
...
[plugins.dashdrm][debug] Ignoring encrypted representation ('0', '16', '27') (video/webm): FFmpeg does not support decryption of this container format

[cli][info] Available streams: 110p (worst), 182p, 272p, 364p, 436p, 546p, 818p, 1090p, 1636p (best)
[cli][info] Opening stream: 110p (dashdrm)

[plugins.dashdrm][debug] Opening DASH reader for: ('0', '10', '10') - video/mp4
[plugins.dashdrm][debug] Opening DASH reader for: ('0', '11', '11') - audio/mp4

Input #0, mov,mp4,m4a,3gp,3g2,mj2:
  Stream #0:0: Video: h264

Input #1, mov,mp4,m4a,3gp,3g2,mj2:
  Stream #1:0: Audio: aac

Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #1:0 -> #0:1 (copy)

[cli][info] Player closed
[cli][info] Stream ended
```